### PR TITLE
Oauth Mock Refactor

### DIFF
--- a/spec/features/user/user_accesses_personal_page_spec.rb
+++ b/spec/features/user/user_accesses_personal_page_spec.rb
@@ -1,11 +1,15 @@
 require 'rails_helper'
 
   describe "user visits root page" do
+    
+    before(:each) do 
+      mock_auth_hash
+      visit root_path
+      click_link "Sign in with Google"
+    end
+
     context "it clicks profile button" do
       it "is taken to profile page" do
-        mock_auth_hash
-        visit root_path 
-        click_link "Sign in with Google"
         save_one  = User.first.saves.create(school:"CSU", ethnicity:"hispanic", year:"2016", program:"chem", program_grads:"23", ethnicity_grads:"10",percentage_one:".2", percentage_two:".5")
 
         expect(page).to have_link("Jonathan Serrano")
@@ -17,38 +21,5 @@ require 'rails_helper'
         expect(page).to have_content("CSU")
         expect(page).to have_content("hispanic")
       end
-    
-  def mock_auth_hash
-    OmniAuth.config.test_mode = true
-    OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new({
-        provider: "google",
-        uid: "1234",
-        info: {
-          name: "Jonathan Serrano",
-        },
-        credentials: {
-          token: "1234djdjd",
-          expires_at: DateTime.now,
-        }
-    })
     end
   end
-end
-
-#   def current_user_hash
-#     auth = {
-#       provider: "google",
-#       uid: "1234",
-#       info: {
-#         name: "Jonathan Serrano",
-#       },
-#       credentials: {
-#         token: "abcdefg12345",
-#         expires_at: DateTime.now
-#       }
-#     }
-#     User.create(auth)
-#     current_user = User.first
-#   end
-# end
-# end

--- a/spec/features/user/user_deletes_saved_search_spec.rb
+++ b/spec/features/user/user_deletes_saved_search_spec.rb
@@ -1,11 +1,15 @@
 require 'rails_helper'
 
   describe "user visits profile page" do
+
+    before(:each) do
+      mock_auth_hash
+      visit root_path 
+      click_link "Sign in with Google"
+    end
+
     context "it clicks delete button" do
       it "removes saved record from page" do
-        mock_auth_hash
-        visit root_path 
-        click_link "Sign in with Google"
         save_one  = User.first.saves.create(school:"CSU", ethnicity:"hispanic", year:"2016", program:"chem", program_grads:"23", ethnicity_grads:"10",percentage_one:".2", percentage_two:".5")
         click_link "Jonathan Serrano"
 
@@ -17,21 +21,6 @@ require 'rails_helper'
         expect(page).to_not have_content("CSU")
         expect(page).to_not have_content("hispanic")
         expect(page).to_not have_content("2016")
-      end      
-
-  def mock_auth_hash
-    OmniAuth.config.test_mode = true
-    OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new({
-        provider: "google",
-        uid: "1234",
-        info: {
-          name: "Jonathan Serrano",
-        },
-        credentials: {
-          token: "1234djdjd",
-          expires_at: DateTime.now,
-        }
-    })
+      end 
     end
   end
-end

--- a/spec/features/user/user_logs_in_spec.rb
+++ b/spec/features/user/user_logs_in_spec.rb
@@ -1,8 +1,12 @@
 require 'rails_helper'
  
   describe "user logs in" do
-    scenario "using google oauth2" do
+
+    before(:each) do
       mock_auth_hash
+    end
+
+    scenario "using google oauth2" do
       visit root_path
 
       expect(page).to have_link("Sign in with Google")
@@ -11,20 +15,5 @@ require 'rails_helper'
 
       expect(page).to have_content("Jonathan Serrano")
       expect(page).to have_link("Sign out")
-    end
-
-  def mock_auth_hash
-    OmniAuth.config.test_mode = true
-    OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new({
-        provider: "google",
-        uid: "1234",
-        info: {
-          name: "Jonathan Serrano",
-        },
-        credentials: {
-          token: "1234djdjd",
-          expires_at: DateTime.now,
-        }
-    })
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,12 +9,21 @@ require 'rspec/rails'
 require 'webmock/rspec'
 require 'support/factory_girl'
 require 'vcr'
+require 'support/omniauth_macros'
+
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/cassettes'
   config.hook_into :webmock
   config.allow_http_connections_when_no_cassette = true
 end
 
+  RSpec.configure do |config|
+  # ...
+  # include our macro
+    config.include(OmniauthMacros)
+  end
+
+  OmniAuth.config.test_mode = true
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/support/omniauth_macros.rb
+++ b/spec/support/omniauth_macros.rb
@@ -1,6 +1,5 @@
 module OmniauthMacros
   def mock_auth_hash
-    OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new({
         provider: "google",
         uid: "1234",


### PR DESCRIPTION
Adds mock_auth_hash module in spec/support.
Mock_auth_hash to be used by the rest of the test suite. 
Extracts mock_auth_hash method code and calls method from individual tests.